### PR TITLE
Switch from admin to user API keys for REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ usage: fetchmonitors.py [-h] --sourceAccount SOURCEACCOUNT
 Parameter        | Note
 ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 sourceAccount    | Account to fetch monitors from
-sourceApiKey     | This should be the Admin API Key for sourceAccount
+sourceApiKey     | This should be a User API Key for sourceAccount for a user with admin (or add on / custom role equivalent) access to Synthetics
 insightsQueryKey | must be supplied to fetch secure credentials from Insights for any monitors that ran in the past 7 days. Secure credentials fetching is skipped if this is not passed.
 toFile           | should only be a file name e.g. soure-monitors.csv. It will always be created in output/ directory
 
@@ -166,9 +166,9 @@ Parameter     | Note
 ------------- | --------------------------------------------------------------------------------------------------------
 fromFile      | must contain monitor names one per line
 sourceAccount | Account to fetch monitors from
-sourceApiKey  | This should be the Admin API Key for sourceAccount
+sourceApiKey  | This should be a User API Key for sourceAccount for a user with admin (or add on / custom role equivalent) access to Synthetics
 targetAccount | Account to migrate monitors to
-targetApiKey  | This should be the Admin API Key for targetAccount
+targetApiKey  | This should be a User API Key for targetAccount for a user with admin (or add on / custom role equivalent) access to Synthetics
 personalApiKey | Personal API Key used for GraphQL API Client calls (required to apply tags)
 timeStamp     | must match the timeStamp generated in fetchmonitors , used when useLocal flag is passed
 useLocal      | By default monitors are fetched from sourceAccount. A pre-fetched copy can be used by passing this flag.
@@ -199,9 +199,9 @@ Parameter     | Note
 ------------- | ------------------------------------------------------------------------------------------------------
 fromFile      | must contain alert policy names one per line
 sourceAccount | Account to fetch monitors from
-sourceApiKey  | Admin API Key for sourceAccount
+sourceApiKey  | User API Key for sourceAccount for a user with admin (or add on / custom role equivalent) access to Alerts
 targetAccount | Account to migrate policies to
-targetApiKey  | Admin API Key for targetAccount
+targetApiKey  | User API Key for targetAccount for a user with admin (or add on / custom role equivalent) access to Alerts
 useLocal      | By alert channels are fetched from sourceAccount. A pre-fetched copy can be used by passing this flag.
 
 The script migrates alert policies to target account if not present in target account.
@@ -227,9 +227,9 @@ Parameter      | Note
 fromFile       | must contain alert policy names one per line
 personalApiKey | Personal API Key used for GraphQL API Client calls
 sourceAccount  | Account to fetch monitors from
-sourceApiKey   | Admin API Key for sourceAccount
+sourceApiKey   | User API Key for sourceAccount for a user with admin (or add on / custom role equivalent) access to Alerts
 targetAccount  | Account to migrate policies to
-targetApiKey   | Admin API Key for targetAccount
+targetApiKey   | User API Key for targetAccount for a user with admin (or add on / custom role equivalent) access to Alerts
 synthetics     | Pass this flag to migrate synthetic conditions
 app_conditions | Pass this flag to migrate alert conditions for APM, Browser apps, Key Transactions
 nrql_conditions | Migrate nrql conditions in the alert policies
@@ -286,7 +286,7 @@ Parameter     | Note
 ------------- | -------------------------------------------------------------------------
 fromFile      | specifies the file with relative path, listing the monitors to be updated
 targetAccount | Account in which monitors need to be updated
-targetApiKey  | This should be the Admin API Key for targetAccount
+targetApiKey  | This should be a User API Key for targetAccount for a user with admin (or add on / custom role equivalent) access to Synthetics
 timeStamp     | must match the timeStamp generated in fetchmonitors
 renamePrefix  | Monitors are renamed with this prefix
 disable       | Monitors are disabled

--- a/deleteallmonitors.py
+++ b/deleteallmonitors.py
@@ -36,8 +36,8 @@ def setup_headers(api_key):
         target_api_key = api_key
     else:
         target_api_key = os.environ.get('ENV_TARGET_API_KEY')
-    headers['X-Api-Key'] = target_api_key
-    if not headers['X-Api-Key']:
+    headers['Api-Key'] = target_api_key
+    if not headers['Api-Key']:
         logger.error('Error: Missing API Key. either pass as param ---targetApiKey or \
             environment variable ENV_TARGET_API_KEY.\n \
             e.g. export ENV_TARGET_API_KEY="NRNA7893asdfhkh"')

--- a/deletemonitors.py
+++ b/deletemonitors.py
@@ -36,8 +36,8 @@ def setup_headers():
         target_api_key = args.targetApiKey[0]
     else:
         target_api_key = os.environ.get('ENV_TARGET_API_KEY')
-    headers['X-Api-Key'] = target_api_key
-    if not headers['X-Api-Key']:
+    headers['Api-Key'] = target_api_key
+    if not headers['Api-Key']:
         logger.error('Error: Missing API Key. either pass as param ---targetApiKey or \
             environment variable ENV_TARGET_API_KEY.\n \
             e.g. export ENV_TARGET_API_KEY="NRNA7893asdfhkh"')

--- a/fetchlabels.py
+++ b/fetchlabels.py
@@ -22,7 +22,7 @@ def setup_params():
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key}
+    return {'Api-Key': api_key}
 
 
 def print_params():

--- a/fetchmonitors.py
+++ b/fetchmonitors.py
@@ -10,7 +10,7 @@ import library.securecredentials as securecredentials
 
 # fetch monitors from an account
 # sourceAccount : account to fetch the monitors from
-# sourceApiKey : Admin API Key for the account
+# sourceApiKey : User API Key for the account for a user with admin (or add on / custom role equivalent) access to Synthetics
 # toFile : file name only for the output file
 # the toFile will be written to output sub-directory
 # If file exists then it will be overwritten
@@ -51,10 +51,10 @@ def setup_headers(api_key):
     global source_api_key
     if args.sourceApiKey:
         source_api_key = api_key
-        headers['X-Api-Key'] = args.sourceApiKey[0]
+        headers['Api-Key'] = args.sourceApiKey[0]
     else:
         source_api_key = os.environ.get('ENV_SOURCE_API_KEY')
-        headers['X-Api-Key'] = source_api_key
+        headers['Api-Key'] = source_api_key
     logger.debug(headers)
     validate_keys()
 

--- a/library/clients/alertsclient.py
+++ b/library/clients/alertsclient.py
@@ -48,7 +48,7 @@ POLICY_NAME = 'policy_name'
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def get_all_alert_policies(api_key):

--- a/library/clients/entityclient.py
+++ b/library/clients/entityclient.py
@@ -31,7 +31,7 @@ logger = m_logger.get_logger(os.path.basename(__file__))
 
 
 def rest_api_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def gql_headers(api_key):

--- a/library/clients/monitorsclient.py
+++ b/library/clients/monitorsclient.py
@@ -21,7 +21,7 @@ MON_SEC_CREDENTIALS = 'secureCredentials'
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def fetch_script(api_key, monitor_id):

--- a/library/clients/violationsclient.py
+++ b/library/clients/violationsclient.py
@@ -11,7 +11,7 @@ VIOLATIONS = 'violations'
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def get_all_alert_violations(api_key, start_date, end_date, only_open):

--- a/library/securecredentials.py
+++ b/library/securecredentials.py
@@ -14,7 +14,7 @@ query_secure_credentials_for = "FROM SyntheticCheck SELECT uniques(secureCredent
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def from_script(script):

--- a/library/utils.py
+++ b/library/utils.py
@@ -11,7 +11,7 @@ logger = m_logger.get_logger(os.path.basename(__file__))
 
 
 def setup_headers(api_key):
-    return {'X-Api-Key': api_key, 'Content-Type': 'Application/JSON'}
+    return {'Api-Key': api_key, 'Content-Type': 'Application/JSON'}
 
 
 def get_next_url(rsp_headers):


### PR DESCRIPTION
Addresses issue: https://github.com/newrelic-experimental/nr-account-migration/issues/8

- Removes admin API key references (including documentation)
- Changes the API key header from X-Api-Key to Api-Key