### PR TITLE
Added option to match source account alert condition state

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ If alert policy is present then only notification channels are migrated if not p
 
 Any target APM , Browser, Mobile apps and Key transactions must be migrated manually.
 
-`usage: migrateconditions.py [-h] --fromFile FROMFILE --personalApiKey PERSONALAPIKEY --sourceAccount SOURCEACCOUNT --sourceApiKey SOURCEAPIKEY --targetAccount TARGETACCOUNT [--targetApiKey TARGETAPIKEY] [--synthetics --app_conditions --nrql_conditions --infra_conditions]`
+`usage: migrateconditions.py [-h] --fromFile FROMFILE --personalApiKey PERSONALAPIKEY --sourceAccount SOURCEACCOUNT --sourceApiKey SOURCEAPIKEY --targetAccount TARGETACCOUNT [--targetApiKey TARGETAPIKEY] [--matchSourceState] [--synthetics --app_conditions --nrql_conditions --infra_conditions]`
 
 Parameter      | Note
 -------------- | --------------------------------------------------
@@ -232,6 +232,7 @@ sourceAccount  | Account to fetch monitors from
 sourceApiKey   | User API Key for sourceAccount for a user with admin (or add on / custom role equivalent) access to Alerts
 targetAccount  | Account to migrate policies to
 targetApiKey   | User API Key for targetAccount for a user with admin (or add on / custom role equivalent) access to Alerts
+matchSourceState | Match alert condition enabled/disabled state from the source account in the target account. By default, all copied alert conditions are disabled in the target account.
 synthetics     | Pass this flag to migrate synthetic conditions
 app_conditions | Pass this flag to migrate alert conditions for APM, Browser apps, Key Transactions
 nrql_conditions | Migrate nrql conditions in the alert policies

--- a/library/migrator/extsvc_conditions.py
+++ b/library/migrator/extsvc_conditions.py
@@ -24,7 +24,7 @@ def get_entity_type(extsvc_condition):
         return ec.MOBILE_APP
 
 
-def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy):
+def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy, match_source_status):
     log.info('loading source ext svc conditions')
     extsvc_conditions = ac.get_extsvc_conditions(src_api_key, src_policy['id'])[ac.EXTSVC_CONDITIONS]
     if len(extsvc_conditions) <= 0:
@@ -63,7 +63,7 @@ def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy,
         if len(tgt_entities) > 0:
             update_condition_status(all_alert_status, cond_row, entity_ids, tgt_acct_id,
                                     tgt_entities)
-            tgt_condition = create_tgt_extsvc_condition(extsvc_condition, tgt_entities)
+            tgt_condition = create_tgt_extsvc_condition(extsvc_condition, tgt_entities, match_source_status)
             result = ac.create_extsvc_condition(tgt_api_key, tgt_policy, tgt_condition)
             all_alert_status[cond_row][cs.STATUS] = result['status']
             if cs.ERROR in result.keys():
@@ -98,9 +98,10 @@ def update_condition_status(all_alert_status, condition_row, entity_ids, tgt_acc
     all_alert_status[condition_row][cs.TGT_ENTITY] = tgt_entities
 
 
-def create_tgt_extsvc_condition(extsvc_condition, tgt_entities):
+def create_tgt_extsvc_condition(extsvc_condition, tgt_entities, match_source_status):
     tgt_condition = extsvc_condition.copy()
     tgt_condition.pop('id')
-    tgt_condition['enabled'] = False
+    if match_source_status == False:
+        tgt_condition['enabled'] = False
     tgt_condition[ac.ENTITIES] = tgt_entities
     return tgt_condition

--- a/library/migrator/infra_conditions.py
+++ b/library/migrator/infra_conditions.py
@@ -5,7 +5,7 @@ import library.clients.alertsclient as ac
 
 logger = logger.get_logger(os.path.basename(__file__))
 
-def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy):
+def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy, match_source_status):
     logger.info('Loading source infrastructure conditions ')
     infra_conditions = ac.get_infra_conditions(src_api_key, src_policy['id'])[ac.INFRA_CONDITIONS]
     logger.info('Found infrastructure conditions ' + str(len(infra_conditions)))
@@ -18,17 +18,18 @@ def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy,
         all_alert_status[condition_row] = {cs.COND_NAME: infra_condition['name']}
         if infra_condition['name'] not in tgt_infra_conds:
             logger.info('Creating target infrastructure condition ' + infra_condition['name'])
-            tgt_condition = create_tgt_infra_condition(infra_condition, tgt_policy['id'])
+            tgt_condition = create_tgt_infra_condition(infra_condition, tgt_policy['id'], match_source_status)
             result = ac.create_infra_condition(tgt_api_key, tgt_policy, tgt_condition)
             all_alert_status[condition_row][cs.STATUS] = result['status']
             if 'error' in result.keys():
                 all_alert_status[condition_row][cs.ERROR] = result['error']
 
-def create_tgt_infra_condition(infra_condition, tgt_pol_id):
+def create_tgt_infra_condition(infra_condition, tgt_pol_id, match_source_status):
     tgt_condition = infra_condition.copy()
     tgt_condition.pop('id')
     tgt_condition.pop('created_at_epoch_millis')
     tgt_condition.pop('updated_at_epoch_millis')
     tgt_condition['policy_id'] = tgt_pol_id
-    tgt_condition['enabled'] = False
+    if match_source_status == False:
+        tgt_condition['enabled'] = False
     return tgt_condition

--- a/library/migrator/nrql_conditions.py
+++ b/library/migrator/nrql_conditions.py
@@ -6,7 +6,7 @@ import library.clients.alertsclient as ac
 logger = logger.get_logger(os.path.basename(__file__))
 
 
-def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy):
+def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy, tgt_acct_id, tgt_api_key, tgt_policy, match_source_status):
     logger.info('Loading NRQL conditions ')
     result = ac.get_nrql_conditions(src_api_key, src_policy['id'])
     nrql_conds = []
@@ -23,15 +23,16 @@ def migrate(all_alert_status, per_api_key, policy_name, src_api_key, src_policy,
         all_alert_status[condition_row] = {cs.COND_NAME: nrql_condition['name']}
         if nrql_condition['name'] not in tgt_nrql_conds:
             logger.info('Creating target NRQL condition ' + nrql_condition['name'])
-            tgt_condition = create_tgt_nrql_condition(nrql_condition)
+            tgt_condition = create_tgt_nrql_condition(nrql_condition, match_source_status)
             result = ac.create_nrql_condition(tgt_api_key, tgt_policy, tgt_condition)
             all_alert_status[condition_row][cs.STATUS] = result['status']
             if 'error' in result.keys():
                 all_alert_status[condition_row][cs.ERROR] = result['error']
 
 
-def create_tgt_nrql_condition(nrql_condition):
+def create_tgt_nrql_condition(nrql_condition, match_source_status):
     tgt_condition = nrql_condition.copy()
     tgt_condition.pop('id')
-    tgt_condition['enabled'] = False
+    if match_source_status == False:
+        tgt_condition['enabled'] = False
     return tgt_condition


### PR DESCRIPTION
A flag (--matchSourceState) can now be passed into migrateconditions.py to override the default behavior of disabling all alert conditions migrated to the target account. This behavior was described in https://github.com/newrelic-experimental/nr-account-migration/issues/13.